### PR TITLE
Pinia-States für Verifikation und Wählen hinzugefügt

### DIFF
--- a/wahlapp/src/stores/statesStore.js
+++ b/wahlapp/src/stores/statesStore.js
@@ -1,0 +1,15 @@
+import { defineStore } from 'pinia';
+import { ref } from "vue";
+
+export const useStatesStore = defineStore('states', {
+  state: () => ({
+    verifiziert: ref(false),
+    gewaehlt: ref(false),
+  }),
+  actions: {
+    submitWahl() { /* Hier könnten Stimmen an Server gesendet werden */
+      this.gewaehlt = true;
+      /* erweitertes todo: Eintragen der Stimmen in eine Datenbank */
+    }
+  }
+});

--- a/wahlapp/src/stores/wahlStore.js
+++ b/wahlapp/src/stores/wahlStore.js
@@ -22,8 +22,6 @@ export const useWahlStore = defineStore('wahl', {
       { id: 5, name: "Bauer, Karl", text: "Sozialpädagoge, Die Linke", num: 5 },
       { id: 6, name: "Schulze, Maria", text: "Unternehmerin, AfD", num: 6 },
     ],
-    // Anzahl der Stimmen
-    counter: ref(0),
     sicherheitsinformationen: ["GG BRD",
         "Art 38",
         "(1) Die Abgeordneten des Deutschen Bundestages werden in allgemeiner, unmittelbarer, freier, gleicher und geheimer Wahl gewählt. Sie sind Vertreter des ganzen Volkes, an Aufträge und Weisungen nicht gebunden und nur ihrem Gewissen unterworfen.",
@@ -48,12 +46,6 @@ export const useWahlStore = defineStore('wahl', {
     },
     getZweitstimmebyId(id) {
         return this.parteien.find((stimme) => stimme.id === id);
-    },
-    submitWahl() { /* Hier könnten Stimmen an Server gesendet werden */
-      this.counter++;
-      console.log("Stimmen abgegeben: ", this.counter);
-      /* todo: Eintragen der Stimmen in eine Datenbank */
-
     }
   }
 });


### PR DESCRIPTION
Nun sind beide State-Variablen nutzbar, um erneutes Wählen zu verhindern bzw. die Reihenfolge Verifikation-> Wahl zu gewährleisten